### PR TITLE
Handle permission denied scenario

### DIFF
--- a/example/web/channels/user_socket.ex
+++ b/example/web/channels/user_socket.ex
@@ -1,6 +1,7 @@
 defmodule ElmPhoenix.UserSocket do
   use Phoenix.Socket
   require Logger
+  require Integer
 
   ## Channels
   channel "room:*", ElmPhoenix.RoomChannel
@@ -22,7 +23,13 @@ defmodule ElmPhoenix.UserSocket do
   # performing token verification on connect.
   def connect(params, socket) do
     Logger.debug "Socket params: #{inspect params}"
-    {:ok, socket}
+    accessToken = String.to_integer params["accessToken"]
+
+    if Integer.is_odd accessToken do
+      {:ok, socket}
+    else
+     :error
+    end
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/example/web/elm/src/Chat.elm
+++ b/example/web/elm/src/Chat.elm
@@ -77,12 +77,12 @@ type Msg
     | UserJoinedMsg JD.Value
     | UserLeftMsg JD.Value
     | SendComposedMessage
-    | RefreshAccessToken
+    | SocketClosedAbnormally
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update message model =
-    case message of
+    case Debug.log "update" message of
         UpdateUserName name ->
             { model | userName = name, userNameTaken = False } ! []
 
@@ -127,7 +127,7 @@ update message model =
                 Err err ->
                     model ! []
 
-        RefreshAccessToken ->
+        SocketClosedAbnormally ->
             { model | accessToken = model.accessToken + 1 } ! []
 
 
@@ -169,7 +169,7 @@ socket : Int -> Socket Msg
 socket accessToken =
     Socket.init lobbySocket
         |> Socket.withParams [ ( "accessToken", toString accessToken ) ]
-        |> Socket.onAbnormalClose RefreshAccessToken
+        |> Socket.onAbnormalClose SocketClosedAbnormally
 
 
 lobby : String -> Channel Msg

--- a/src/Phoenix.elm
+++ b/src/Phoenix.elm
@@ -502,27 +502,24 @@ onSelfMsg router selfMsg state =
                             Task.map (updateSocket endpoint (InternalSocket.opening backoffIteration pid internalSocket)) getNewState
 
                         notifyOnClose =
-                            if InternalSocket.isOpening internalSocket then
-                                Task.succeed ()
-                            else
-                                Maybe.map (\onClose -> Platform.sendToApp router (onClose details)) socket.onClose
-                                    |> Maybe.withDefault (Task.succeed ())
+                            Maybe.map (\onClose -> Platform.sendToApp router (onClose details)) socket.onClose
+                                |> Maybe.withDefault (Task.succeed ())
 
                         notifyOnNormalClose =
                             -- see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent for error codes
-                            if InternalSocket.isOpening internalSocket || details.code /= 1000 then
-                                Task.succeed ()
-                            else
+                            if details.code == 1000 then
                                 Maybe.map (Platform.sendToApp router) socket.onNormalClose
                                     |> Maybe.withDefault (Task.succeed ())
+                            else
+                                Task.succeed ()
 
                         notifyOnAbnormalClose =
                             -- see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent for error codes
-                            if InternalSocket.isOpening internalSocket || details.code /= 1006 then
-                                Task.succeed ()
-                            else
+                            if details.code == 1006 then
                                 Maybe.map (Platform.sendToApp router) socket.onAbnormalClose
                                     |> Maybe.withDefault (Task.succeed ())
+                            else
+                                Task.succeed ()
                     in
                         notifyOnClose
                             &> notifyOnNormalClose


### PR DESCRIPTION
Overview of discussion from slack with @saschatimme:

When a socket connection is dropped elm-phoenix will keep attempting to reconnect (on a backoff schedule). When the connection is first dropped the `onAbnormalClose` subscription is triggered, subsequent failed attempts to reconnect however don't trigger `onAbnormalClose`. The intention was to prevent the app being spammed with `onAbnormalClose` msgs. In the following scenario this is problematic:

1) Socket connects successfully with a JWT token
2) Socket connection is dropped
3) Socket attempts to reconnect but JWT is now stale

(2) causes `onAbnormalClose` to be triggered but (3) is considered the second abnormal close so `onAbnormalClose` is not triggered. Ideally it would be possible to trigger different subscriptions e.g. `onNetworkDown` or `onPermissionDenied`. However the websocket spec deliberately conceals the reason for the bad connection (see https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent for a list of response codes). Frustratingly the http connection that the websocket uses does actually report a 403, but the websocket API doesn't allow access to this status code. 

To resolve the stale JWT scenario above it's necessary to trigger the `onAbnormalClose` on every failed connection (the websocket spec doesn't distinguish between a dropped connection or a failed attempt to connect). This allows the app to check whether the JWT is fresh and to take action and refresh it if necessary. 

This PR changes the behaviour for `onClose`, `onNormalClose` and `onAbnormalClose` to always trigger regardless of whether or not it's the first attempt (previously established by checking the current state of the socket).

To test the behaviour run the example and load it in the browser, kill the server then restart it. The console gives an overview of what's happening (we have discussed using Wallaby to add test coverage but will add those at a later date).