### PR TITLE
Add presence

### DIFF
--- a/documentation.json
+++ b/documentation.json
@@ -19,89 +19,6 @@
     "generated-with-elm-version": "0.18.0"
   },
   {
-    "name": "Phoenix.Channel",
-    "comment": " A channel declares which topic should be joined, registers event handlers and has various callbacks for possible lifecycle events.\n\n# Definition\n@docs Channel\n\n# Helpers\n@docs init, withPayload, on, onJoin, onRequestJoin, onJoinError, onError, onDisconnect, onRejoin, onLeave, onLeaveError, withDebug, map\n\n",
-    "aliases": [
-      {
-        "name": "Channel",
-        "comment": " Representation of a Phoenix Channel\n",
-        "args": [
-          "msg"
-        ],
-        "type": "Phoenix.Channel.PhoenixChannel msg"
-      }
-    ],
-    "types": [],
-    "values": [
-      {
-        "name": "init",
-        "comment": " Initialize a channel to a given topic.\n\n    init \"room:lobby\"\n",
-        "type": "String -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "map",
-        "comment": " Composes each callback with the function `a -> b`.\n",
-        "type": "(a -> b) -> Phoenix.Channel.Channel a -> Phoenix.Channel.Channel b"
-      },
-      {
-        "name": "on",
-        "comment": " Register an event handler for a event.\n\n    type Msg = NewMsg Value | ...\n\n    init \"roomy:lobby\"\n        |> on \"new_msg\" NewMsg\n",
-        "type": "String -> (Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onDisconnect",
-        "comment": " Set a callback which will be called if the socket connection got interrupted. Useful to switch the online status to offline.\n\n    type Msg =\n        IsOffline | ...\n\n    init \"room:lobby\"\n        |> onDisconnect IsOffline\n\n**Note**: The effect manager will automatically try to reconnect to the server and to rejoin the channel. See `onRejoin` for details.\n",
-        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onError",
-        "comment": " Set a callback which will be called if the channel process on the server crashed. The effect manager will automatically rejoin the channel after a crash.\n\n    type Msg =\n         ChannelCrashed | ...\n\n    init \"room:lobby\"\n        |> onError ChannelCrashed\n",
-        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onJoin",
-        "comment": " Set a callback which will be called after you sucessfully joined the channel. It will also be called after you rejoined the channel after a disconnect unless you specified an `onRejoin` handler.\n\n    type Msg =\n        IsOnline Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onJoin IsOnline\n",
-        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onJoinError",
-        "comment": " Set a callback which will be called if the server declined your request to join the channel.\n\n    type Msg =\n        CouldNotJoin Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onJoinError CouldNotJoin\n\n**Note**: If a channel declined a request to join a topic the effect manager won_t try again.\n",
-        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onLeave",
-        "comment": " Set a callback which will be called after you sucessfully left a channel.\n\n    type Msg =\n        LeftLobby Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onLeave LeftLobby\n",
-        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onLeaveError",
-        "comment": " Set a callback which will be called if the server declined your request to left a channel.\n*(It seems that Phoenix v1.2 doesn_t send this)*\n",
-        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onRejoin",
-        "comment": " Set a callback which will be called after you sucessfully rejoined the channel after a disconnect. Useful if you want to catch up missed messages.\n\n    type Msg =\n        IsOnline Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onRejoin IsOnline\n",
-        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "onRequestJoin",
-        "comment": " Set a callback which will be called after you request to join the channel.\n\n    type Msg =\n        JoinLobbyRequested\n\n    init \"room:lobby\"\n        |> onRequestJoin JoinLobbyRequested\n",
-        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "withDebug",
-        "comment": " Print all status changes.\n",
-        "type": "Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      },
-      {
-        "name": "withPayload",
-        "comment": " Attach a payload to the join message. You can use this to submit e.g. a user id or authentication infos. This will be the second argument in your `join/3` callback on the server.\n\n    payload =\n        Json.Encode.object [(\"user_id\", \"123\")]\n\n    init \"room:lobby\"\n        |> withPayload payload\n",
-        "type": "Json.Decode.Value -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
-      }
-    ],
-    "generated-with-elm-version": "0.18.0"
-  },
-  {
     "name": "Phoenix.Socket",
     "comment": " A socket declares to which endpoint a socket connection should be established.\n\n# Definition\n@docs Socket, AbnormalClose\n\n# Helpers\n@docs init, withParams, heartbeatIntervallSeconds, withoutHeartbeat, reconnectTimer, withDebug, onAbnormalClose, onNormalClose, onOpen, onClose, map\n",
     "aliases": [
@@ -176,6 +93,94 @@
         "name": "withoutHeartbeat",
         "comment": " The client regularly sends a heartbeat to the sever. With this function you can disable the heartbeat.\n\n    init \"ws://localhost:4000/socket/websocket\"\n        |> withoutHeartbeat\n",
         "type": "Phoenix.Socket.Socket msg -> Phoenix.Socket.Socket msg"
+      }
+    ],
+    "generated-with-elm-version": "0.18.0"
+  },
+  {
+    "name": "Phoenix.Channel",
+    "comment": " A channel declares which topic should be joined, registers event handlers and has various callbacks for possible lifecycle events.\n\n# Definition\n@docs Channel\n\n# Helpers\n@docs init, withPayload, on, onJoin, onRequestJoin, onJoinError, onError, onDisconnect, onRejoin, onLeave, onLeaveError, withDebug, map\n@docs init, withPayload, on, onJoin, onRequestJoin, onJoinError, onError, onDisconnect, onRejoin, onLeave, onLeaveError, onPresenceChange, withDebug, map\n\n",
+    "aliases": [
+      {
+        "name": "Channel",
+        "comment": " Representation of a Phoenix Channel\n",
+        "args": [
+          "msg"
+        ],
+        "type": "Phoenix.Channel.PhoenixChannel msg"
+      }
+    ],
+    "types": [],
+    "values": [
+      {
+        "name": "init",
+        "comment": " Initialize a channel to a given topic.\n\n    init \"room:lobby\"\n",
+        "type": "String -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "map",
+        "comment": " Composes each callback with the function `a -> b`.\n",
+        "type": "(a -> b) -> Phoenix.Channel.Channel a -> Phoenix.Channel.Channel b"
+      },
+      {
+        "name": "on",
+        "comment": " Register an event handler for a event.\n\n    type Msg = NewMsg Value | ...\n\n    init \"roomy:lobby\"\n        |> on \"new_msg\" NewMsg\n",
+        "type": "String -> (Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onDisconnect",
+        "comment": " Set a callback which will be called if the socket connection got interrupted. Useful to switch the online status to offline.\n\n    type Msg =\n        IsOffline | ...\n\n    init \"room:lobby\"\n        |> onDisconnect IsOffline\n\n**Note**: The effect manager will automatically try to reconnect to the server and to rejoin the channel. See `onRejoin` for details.\n",
+        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onError",
+        "comment": " Set a callback which will be called if the channel process on the server crashed. The effect manager will automatically rejoin the channel after a crash.\n\n    type Msg =\n         ChannelCrashed | ...\n\n    init \"room:lobby\"\n        |> onError ChannelCrashed\n",
+        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onJoin",
+        "comment": " Set a callback which will be called after you sucessfully joined the channel. It will also be called after you rejoined the channel after a disconnect unless you specified an `onRejoin` handler.\n\n    type Msg =\n        IsOnline Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onJoin IsOnline\n",
+        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onJoinError",
+        "comment": " Set a callback which will be called if the server declined your request to join the channel.\n\n    type Msg =\n        CouldNotJoin Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onJoinError CouldNotJoin\n\n**Note**: If a channel declined a request to join a topic the effect manager won_t try again.\n",
+        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onLeave",
+        "comment": " Set a callback which will be called after you sucessfully left a channel.\n\n    type Msg =\n        LeftLobby Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onLeave LeftLobby\n",
+        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onLeaveError",
+        "comment": " Set a callback which will be called if the server declined your request to left a channel.\n*(It seems that Phoenix v1.2 doesn_t send this)*\n",
+        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onPresenceChange",
+        "comment": " Set a callback which will be called when there is a change in the presence state caused by \"presence_state\" and \"presence_diff\" events.\n\n    type Msg =\n        PresenceChange (Dict String (List Json.Encode.Value)) | ...\n\n    init \"room:lobby\"\n        |> onPresenceChange PresenceChange\n",
+        "type": "(Dict.Dict String (List Json.Decode.Value) -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onRejoin",
+        "comment": " Set a callback which will be called after you sucessfully rejoined the channel after a disconnect. Useful if you want to catch up missed messages.\n\n    type Msg =\n        IsOnline Json.Encode.Value | ...\n\n    init \"room:lobby\"\n        |> onRejoin IsOnline\n",
+        "type": "(Json.Decode.Value -> msg) -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "onRequestJoin",
+        "comment": " Set a callback which will be called after you request to join the channel.\n\n    type Msg =\n        JoinLobbyRequested\n\n    init \"room:lobby\"\n        |> onRequestJoin JoinLobbyRequested\n",
+        "type": "msg -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "withDebug",
+        "comment": " Print all status changes.\n",
+        "type": "Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
+      },
+      {
+        "name": "withPayload",
+        "comment": " Attach a payload to the join message. You can use this to submit e.g. a user id or authentication infos. This will be the second argument in your `join/3` callback on the server.\n\n    payload =\n        Json.Encode.object [(\"user_id\", \"123\")]\n\n    init \"room:lobby\"\n        |> withPayload payload\n",
+        "type": "Json.Decode.Value -> Phoenix.Channel.Channel msg -> Phoenix.Channel.Channel msg"
       }
     ],
     "generated-with-elm-version": "0.18.0"

--- a/src/Phoenix/Internal/Presence.elm
+++ b/src/Phoenix/Internal/Presence.elm
@@ -1,0 +1,129 @@
+module Phoenix.Internal.Presence exposing (..)
+
+import Json.Decode as JD exposing (Decoder, Value)
+import Dict exposing (Dict)
+
+
+type alias PresenceState =
+    Dict PresenceKey PresenceStateMetaWrapper
+
+
+type alias PresenceDiff =
+    { leaves : PresenceState
+    , joins : PresenceState
+    }
+
+
+type alias PresenceKey =
+    String
+
+
+type alias PresenceStateMetaWrapper =
+    { metas : List PresenceStateMetaValue }
+
+
+type alias PresenceStateMetaValue =
+    { phx_ref : PresenceRef, payload : Value }
+
+
+type alias PresenceRef =
+    String
+
+
+getPresenceState : PresenceState -> Dict String (List Value)
+getPresenceState presenceState =
+    let
+        getMetas { metas } =
+            metas
+
+        getPayload presenceKey presenceStateMetaWrapper =
+            List.map .payload (getMetas presenceStateMetaWrapper)
+    in
+        Dict.map getPayload presenceState
+
+
+syncPresenceDiff : PresenceDiff -> PresenceState -> PresenceState
+syncPresenceDiff presenceDiff presenceState =
+    let
+        mergeJoins joins state =
+            let
+                mergeMetaWrappers joinMetaWrapper stateMetaWrapper =
+                    PresenceStateMetaWrapper (joinMetaWrapper.metas ++ stateMetaWrapper.metas)
+
+                addedStep key joinMetaWrapper addedMetaWrappers =
+                    Dict.insert key joinMetaWrapper addedMetaWrappers
+
+                retainedStep key joinMetaWrapper stateMetaWrapper addedMetaWrappers =
+                    Dict.insert key (mergeMetaWrappers joinMetaWrapper stateMetaWrapper) addedMetaWrappers
+
+                unchangedStep key stateMetaWrapper addedMetaWrappers =
+                    Dict.insert key stateMetaWrapper addedMetaWrappers
+            in
+                Dict.merge addedStep retainedStep unchangedStep joins state Dict.empty
+
+        mergeLeaves leaves state =
+            let
+                mergeMetaWrappers leaves stateKey stateMetaWrapper =
+                    case Dict.get stateKey leaves of
+                        Nothing ->
+                            stateMetaWrapper
+
+                        Just leaveMetaWrapper ->
+                            let
+                                leaveRefs =
+                                    List.map .phx_ref leaveMetaWrapper.metas
+                            in
+                                stateMetaWrapper.metas
+                                    |> List.filter
+                                        (\metaValue ->
+                                            not (List.any (\phx_ref -> metaValue.phx_ref == phx_ref) leaveRefs)
+                                        )
+                                    |> PresenceStateMetaWrapper
+            in
+                state
+                    |> Dict.map (mergeMetaWrappers leaves)
+                    |> Dict.filter (\_ metaWrapper -> metaWrapper.metas /= [])
+    in
+        presenceState
+            |> mergeJoins presenceDiff.joins
+            |> mergeLeaves presenceDiff.leaves
+
+
+decodePresenceDiff : Value -> Result String PresenceDiff
+decodePresenceDiff payload =
+    JD.decodeValue presenceDiffDecoder payload
+
+
+decodePresenceState : Value -> Result String PresenceState
+decodePresenceState payload =
+    JD.decodeValue presenceStateDecoder payload
+
+
+presenceDiffDecoder : Decoder PresenceDiff
+presenceDiffDecoder =
+    JD.map2 PresenceDiff
+        (JD.field "leaves" <| presenceStateDecoder)
+        (JD.field "joins" <| presenceStateDecoder)
+
+
+presenceStateDecoder : Decoder PresenceState
+presenceStateDecoder =
+    JD.dict presenceStateMetaWrapperDecoder
+
+
+presenceStateMetaWrapperDecoder : Decoder PresenceStateMetaWrapper
+presenceStateMetaWrapperDecoder =
+    JD.map PresenceStateMetaWrapper
+        (JD.field "metas" <| JD.list presenceStateMetaValueDecoder)
+
+
+presenceStateMetaValueDecoder : Decoder PresenceStateMetaValue
+presenceStateMetaValueDecoder =
+    let
+        createFinalRecord phxRef payload =
+            JD.succeed (PresenceStateMetaValue phxRef payload)
+
+        decodeWithPhxRef phxRef =
+            JD.andThen (createFinalRecord phxRef) JD.value
+    in
+        JD.andThen decodeWithPhxRef (JD.field "phx_ref" JD.string)


### PR DESCRIPTION
This adds support for Phoenix presence.

There is a new callback `onPresenceChange` in `Phoenix.Channel` module. The callback is called each time there is a `presence_state` or `presence_diff` event. The callback exposes the current presence state as `Dict String (List Value)`.  It is a dictionary where the key is presence key (such as user id) and the value is a list of payload data such as `[{ phx_ref = "y6aMeMQNuR8=", online_at = "1490470085" },{ phx_ref = "LGFol1M18BM=", online_at = "1490470085" }]` (each user can be connected more than once so we track that).

The presence state is updated internally on `presence_state` and `presence_diff` events.