### PR TITLE
Fix README to have correct instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ subscriptions model =
 ```
 
 ## Installation:
-Since this package is an [effect](https://guide.elm-lang.org/architecture/effects/) manager it is at the moment not aviable via elm package. Thus the recommended way to install the package is to use [elm-github-install](https://github.com/gdotdesign/elm-github-install). Simply add in `elm-package.json` `"saschatimme/elm-phoenix": "0.2.1 <= v < 1.0"` to your dependencies:
+Since this package is an [effect](https://guide.elm-lang.org/architecture/effects/) manager it is at the moment not aviable via elm package. Thus the recommended way to install the package is to use [elm-github-install](https://github.com/gdotdesign/elm-github-install). Simply add in `elm-package.json` `"saschatimme/elm-phoenix": "0.2.1 <= v < 1.0.0"` to your dependencies:
 ```
 # elm-package.json
 {


### PR DESCRIPTION
Why:

* The version range in the README was bad/broken
* e.g. `Error in $: Ran into invalid constraint "0.2.1 <= v < 1.0" for saschatimme/elm-phoenix`

This change addresses the need by:

* Changing 1.0 to 1.0.0