### PR TITLE
Include `Phoenix.Presence` in `exposed-modules`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,8 @@
         "Phoenix",
         "Phoenix.Channel",
         "Phoenix.Socket",
-        "Phoenix.Push"
+        "Phoenix.Push",
+        "Phoenix.Presence"
     ],
     "dependencies": {
         "elm-lang/websocket": "1.0.1 <= v < 2.0.0",


### PR DESCRIPTION
Hi,

I've installed `elm-phoenix` using `elm-github-install` in a new Phoenix project as a dependency and copying example's `Chat.elm` content cannot be compiled due `Phoenix.Presence` not being found.

The error raised is:
```
Elm compile: Main.elm, in elm, to ../js/main.js
I cannot find module 'Phoenix.Presence'.

Module 'Main' is trying to import it.

Potential problems could be:
  * Misspelled the module name
  * Need to add a source directory or new dependency to elm-package.json

```

I being able to bypass this error manually adding `Phoenix.Presence` in `exposed-modules` on `elm-package.json`.

Thanks.
