### PR TITLE
Add travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: false
+
+language: node_js
+node_js: node
+
+cache:
+  directories:
+    - tests/elm-stuff/build-artifacts
+    - tests/elm-stuff/packages
+    - sysconfcpus
+os:
+  - linux
+
+env: ELM_VERSION=0.18.0
+
+before_install:
+  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+
+install:
+  - node --version
+  - npm --version
+  - npm install -g elm@$ELM_VERSION elm-test
+  - git clone https://github.com/NoRedInk/elm-ops-tooling
+  - elm-ops-tooling/with_retry.rb elm package install --yes
+  # Faster compile on Travis.
+  - |
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
+
+script:
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/saschatimme/elm-phoenix.svg?branch=master)](https://travis-ci.org/saschatimme/elm-phoenix)
+
 # elm-phoenix
 
 An Elm client for [Phoenix](http://www.phoenixframework.org) Channels.


### PR DESCRIPTION
This enables a build on travis which you can see an example of here:

https://travis-ci.org/edennis/elm-phoenix/builds/306751666

I've updated your README to include a badge, but you'll obviously need to throw the switch yourself on travis first.