### PR TITLE
Make it possible to use multiple websockets and callbacks

### DIFF
--- a/src/Phoenix/Presence.elm
+++ b/src/Phoenix/Presence.elm
@@ -2,12 +2,16 @@ module Phoenix.Presence exposing (Presence, create, onChange, onJoins, onLeaves,
 
 {-| Presence is an extension for channels to support the Presence feature of Phoenix.
 
+
 # Definition
+
 @docs Presence
 
+
 # Helpers
-@docs init, withPayload, on, onJoin, onRequestJoin, onJoinError, onError, onDisconnect, onRejoin, onLeave, onLeaveError, withDebug, map
-@docs init, withPayload, on, onJoin, onRequestJoin, onJoinError, onError, onDisconnect, onRejoin, onLeave, onLeaveError, withDebug, withPresence, map
+
+@docs create, onChange, onJoins, onLeaves, map
+
 -}
 
 import Dict exposing (Dict)
@@ -48,7 +52,6 @@ then an example would be a Dict with
     { "user1": [{online_at: 1491493666123}]
     , "user2": [{online_at: 1491492646123}, {online_at: 1491492646624}]
     }
-
 
 -}
 onChange : (Dict String (List Value) -> msg) -> PhoenixPresence msg -> PhoenixPresence msg


### PR DESCRIPTION
As described in https://github.com/saschatimme/elm-phoenix/issues/33 the internal state of the effects manager wasn't equipped to handle callbacks for multiple websockets. Using a tuple of the `Endpoint` and `Ref` now makes that possible.

I also had to fix the broken documentation in `Phoenix.Presence` to make `elm-make` stop complaining. The extra whitespace in the diff is due to `elm-format`.