### PR TITLE
Fix: JE.object expects (String, JE.Value) not (String, String)

### DIFF
--- a/channel.html
+++ b/channel.html
@@ -11,18 +11,23 @@
 </head>
 
 <body>
-    
+
     <div class="center">
         <div class="entry-list"><h1 class="entry-list-title">Phoenix.Channel</h1><span class="markdown-entry"><div><p> A channel declares which topic should be joined, registers event handlers and has various callbacks for possible lifecycle events.</p>
 <h1 id="definition">Definition</h1>
-</div></span><div class="docs-entry" id="Channel"><div class="docs-annotation"><span class="hljs-keyword">type</span> <span class="hljs-keyword">alias</span> <a href="#Channel" style="font-weight: bold;">Channel</a> msg <span>=</span> 
+</div></span><div class="docs-entry" id="Channel"><div class="docs-annotation"><span class="hljs-keyword">type</span> <span class="hljs-keyword">alias</span> <a href="#Channel" style="font-weight: bold;">Channel</a> msg <span>=</span>
     PhoenixChannel msg</div><div class="docs-comment"><div><p> Representation of a Phoenix Channel</p>
 </div></div></div><span class="markdown-entry"><div><h1 id="helpers">Helpers</h1>
 </div></span><div class="docs-entry" id="init"><div class="docs-annotation"><a href="#init" style="font-weight: bold;">init</a> <span>:</span> String <span>-&gt;</span> <a href="#Channel">Channel</a> msg</div><div class="docs-comment"><div><p> Initialize a channel to a given topic.</p>
 <pre><code><span class="hljs-title">init</span> <span class="hljs-string">"room:lobby"</span>
 </code></pre></div></div></div><div class="docs-entry" id="withPayload"><div class="docs-annotation"><a href="#withPayload" style="font-weight: bold;">withPayload</a> <span>:</span> Value <span>-&gt;</span> <a href="#Channel">Channel</a> msg <span>-&gt;</span> <a href="#Channel">Channel</a> msg</div><div class="docs-comment"><div><p> Attach a payload to the join message. You can use this to submit e.g. a user id or authentication infos. This will be the second argument in your <code>join/3</code> callback on the server.</p>
 <pre><code><span class="hljs-title">payload</span> =
-    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object [(<span class="hljs-string">"user_id"</span>, <span class="hljs-string">"123"</span>)]
+    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object
+      [
+        ( <span class="hljs-string">"user_id"</span>
+        , <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.string <span class="hljs-string">"123"</span>
+        )
+      ]
 
 <span class="hljs-title">init</span> <span class="hljs-string">"room:lobby"</span>
     |&gt; withPayload payload

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
     <div>
         <div class="center">
-    
+
 
 
 
@@ -40,7 +40,11 @@
 </div></div></div><span class="markdown-entry"><div><h1 id="push-messages">Push messages</h1>
 </div></span><div class="docs-entry" id="push"><div class="docs-annotation"><a href="#push" style="font-weight: bold;">push</a> <span>:</span> String <span>-&gt;</span> <a href="http://package.elm-lang.org/help/Phoenix-Push#Push">Push</a> msg <span>-&gt;</span> Cmd msg</div><div class="docs-comment"><div><p> Pushes a <code>Push</code> message to a particular socket address. The address has to be the same as with which you initalized the <code>Socket</code> in the <code>connect</code> subscription.</p>
 <pre><code><span class="hljs-title">payload</span> =
-    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object [(<span class="hljs-string">"msg"</span>, <span class="hljs-string">"Hello Phoenix"</span>)]
+    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object
+      [ ( <span class="hljs-string">"msg"</span>
+        ,  <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.string <span class="hljs-string">"Hello Phoenix"</span>
+        )
+      ]
 
 <span class="hljs-title">message</span> =
     <span class="hljs-type">Push</span>.init <span class="hljs-string">"room:lobby"</span> <span class="hljs-string">"new_msg"</span>

--- a/push.html
+++ b/push.html
@@ -10,14 +10,14 @@
     <link rel="stylesheet" href="./style.css">
 </head>
 
-<body>    
+<body>
     <div class="center">
-    
 
-    
+
+
     <div class="entry-list"><h1 class="entry-list-title">Phoenix.Push</h1><span class="markdown-entry"><div><p> A message to push informations to a channel.</p>
 <h1 id="definition">Definition</h1>
-</div></span><div class="docs-entry" id="Push"><div class="docs-annotation"><span class="hljs-keyword">type</span> <span class="hljs-keyword">alias</span> <a href="#Push" style="font-weight: bold;">Push</a> msg <span>=</span> 
+</div></span><div class="docs-entry" id="Push"><div class="docs-annotation"><span class="hljs-keyword">type</span> <span class="hljs-keyword">alias</span> <a href="#Push" style="font-weight: bold;">Push</a> msg <span>=</span>
     { topic <span>:</span> String
     , event <span>:</span> String
     , payload <span>:</span> Value
@@ -30,7 +30,11 @@
 <pre><code><span class="hljs-title">init</span> <span class="hljs-string">"room:lobby"</span> <span class="hljs-string">"new_msg"</span>
 </code></pre></div></div></div><div class="docs-entry" id="withPayload"><div class="docs-annotation"><a href="#withPayload" style="font-weight: bold;">withPayload</a> <span>:</span> Value <span>-&gt;</span> <a href="#Push">Push</a> msg <span>-&gt;</span> <a href="#Push">Push</a> msg</div><div class="docs-comment"><div><p> Attach a payload to a message</p>
 <pre><code><span class="hljs-title">payload</span> =
-    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object [(<span class="hljs-string">"msg"</span>, <span class="hljs-string">"Hello Phoenix"</span>)]
+    <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.object
+      [ ( <span class="hljs-string">"msg"</span>
+        , <span class="hljs-type">Json</span>.<span class="hljs-type">Encode</span>.string <span class="hljs-string">"Hello Phoenix"</span>
+        )
+      ]
 
 <span class="hljs-title">init</span> <span class="hljs-string">"room:lobby"</span> <span class="hljs-string">"new_msg"</span>
     |&gt; withPayload


### PR DESCRIPTION
This PR. fixes the documentation in .withPayload functions that originally take (String, String) to (String, JE.Value) as per documentation of that JE.object expects (String, JE.Value) not (String, String)